### PR TITLE
Better handling of unique and sparse index constraints

### DIFF
--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -61,7 +61,7 @@ module Mongoid
 
         # Set index
         unless embedded?
-          index(*Mongoid::Slug::Index.build_index(self.slug_scope_key, self.by_model_type, is_paranoid_doc?))
+          index(*Mongoid::Slug::Index.build_index(self.slug_scope_key, self.by_model_type))
         end
 
         #-- Why is it necessary to customize the slug builder?

--- a/spec/mongoid/index_spec.rb
+++ b/spec/mongoid/index_spec.rb
@@ -5,8 +5,7 @@ describe Mongoid::Slug::Index do
 
   let(:scope_key)     { nil }
   let(:by_model_type) { false }
-  let(:paranoid)      { false }
-  subject { Mongoid::Slug::Index.build_index(scope_key, by_model_type, paranoid) }
+  subject { Mongoid::Slug::Index.build_index(scope_key, by_model_type) }
 
   context "when scope_key is set" do
     let(:scope_key) { :foo }
@@ -14,26 +13,12 @@ describe Mongoid::Slug::Index do
     context "when by_model_type is true" do
       let(:by_model_type) { true }
 
-      context "when paranoid is set" do
-        let(:paranoid) { true }
-        it { should eq [{:_slugs=>1, :foo=>1, :_type=>1}, {:sparse=>true}] }
-      end
-
-      context "when paranoid is not set" do
-        it { should eq [{:_slugs=>1, :foo=>1, :_type=>1}, {:sparse=>true}] }
-      end
+      it { should eq [{:_slugs=>1, :foo=>1, :_type=>1}, {}] }
     end
 
     context "when by_model_type is false" do
 
-      context "when paranoid is set" do
-        let(:paranoid) { true }
-        it { should eq [{:_slugs=>1, :foo=>1}, {:sparse=>true}] }
-      end
-
-      context "when paranoid is not set" do
-        it { should eq [{:_slugs=>1, :foo=>1}, {:unique=>true, :sparse=>true}] }
-      end
+      it { should eq [{:_slugs=>1, :foo=>1}, {}] }
     end
   end
 
@@ -42,26 +27,12 @@ describe Mongoid::Slug::Index do
     context "when by_model_type is true" do
       let(:by_model_type) { true }
 
-      context "when paranoid is set" do
-        let(:paranoid) { true }
-        it { should eq [{:_slugs=>1, :_type=>1}, {:sparse=>true}] }
-      end
-
-      context "when paranoid is not set" do
-        it { should eq [{:_slugs=>1, :_type=>1}, {:sparse=>true}] }
-      end
+      it { should eq [{:_slugs=>1, :_type=>1}, {}] }
     end
 
     context "when by_model_type is false" do
 
-      context "when paranoid is set" do
-        let(:paranoid) { true }
-        it { should eq [{:_slugs=>1}, {:unique=>true, :sparse=>true}] }
-      end
-
-      context "when paranoid is not set" do
-        it { should eq [{:_slugs=>1}, {:unique=>true, :sparse=>true}] }
-      end
+      it { should eq [{:_slugs=>1}, {:unique=>true, :sparse=>true}] }
     end
   end
 end

--- a/spec/mongoid/index_spec.rb
+++ b/spec/mongoid/index_spec.rb
@@ -20,7 +20,7 @@ describe Mongoid::Slug::Index do
       end
 
       context "when paranoid is not set" do
-        it { should eq [{:_slugs=>1, :foo=>1, :_type=>1}, {:unique=>true, :sparse=>true}] }
+        it { should eq [{:_slugs=>1, :foo=>1, :_type=>1}, {:sparse=>true}] }
       end
     end
 
@@ -48,7 +48,7 @@ describe Mongoid::Slug::Index do
       end
 
       context "when paranoid is not set" do
-        it { should eq [{:_slugs=>1, :_type=>1}, {:unique=>true, :sparse=>true}] }
+        it { should eq [{:_slugs=>1, :_type=>1}, {:sparse=>true}] }
       end
     end
 

--- a/spec/mongoid/paranoia_spec.rb
+++ b/spec/mongoid/paranoia_spec.rb
@@ -14,12 +14,12 @@ describe "Mongoid::Paranoia with Mongoid::Slug" do
 
     context "when Mongoid::Paranoia is included" do
       subject { paranoid_doc.class }
-      its(:is_paranoid_doc?){ should be_true }
+      specify { subject.is_paranoid_doc?.should be_true }
     end
 
     context "when Mongoid::Paranoia not included" do
       subject { non_paranoid_doc.class }
-      its(:is_paranoid_doc?){ should be_false }
+      specify { subject.is_paranoid_doc?.should be_false }
     end
   end
 
@@ -28,18 +28,18 @@ describe "Mongoid::Paranoia with Mongoid::Slug" do
     context "when Mongoid::Paranoia is included" do
 
       context "when not destroyed" do
-        its(:paranoid_deleted?){ should be_false }
+        specify { subject.paranoid_deleted?.should be_false }
       end
 
       context "when destroyed" do
         before { subject.destroy }
-        its(:paranoid_deleted?){ should be_true }
+        specify { subject.paranoid_deleted?.should be_true }
       end
     end
 
     context "when Mongoid::Paranoia not included" do
       subject { non_paranoid_doc }
-      its(:paranoid_deleted?){ should be_false }
+      specify { subject.paranoid_deleted?.should be_false }
     end
   end
 
@@ -72,7 +72,7 @@ describe "Mongoid::Paranoia with Mongoid::Slug" do
       after   { ParanoidPermanent.remove_indexes }
       subject { ParanoidPermanent }
 
-      it_should_behave_like "has an index", { _slugs: 1, foo: 1 }, { unique: nil, sparse: true }
+      it_should_behave_like "has an index", { foo: 1, _slugs: 1 }, { unique: nil, sparse: nil }
     end
   end
 

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -534,7 +534,7 @@ module Mongoid
       context "for subclass scope" do
         context "when slug is not scoped by a reference association" do
           subject { BookPolymorphic }
-          it_should_behave_like "has an index", { _type: 1, _slugs: 1 }, { unique: true }
+          it_should_behave_like "has an index", { _type: 1, _slugs: 1 }, { unique: true, sparse: true }
         end
 
         context "when slug is scoped by a reference association" do

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -534,7 +534,7 @@ module Mongoid
       context "for subclass scope" do
         context "when slug is not scoped by a reference association" do
           subject { BookPolymorphic }
-          it_should_behave_like "has an index", { _type: 1, _slugs: 1 }, { unique: true, sparse: true }
+          it_should_behave_like "has an index", { _type: 1, _slugs: 1 }, { sparse: true }
         end
 
         context "when slug is scoped by a reference association" do

--- a/spec/mongoid/slug_spec.rb
+++ b/spec/mongoid/slug_spec.rb
@@ -534,7 +534,7 @@ module Mongoid
       context "for subclass scope" do
         context "when slug is not scoped by a reference association" do
           subject { BookPolymorphic }
-          it_should_behave_like "has an index", { _type: 1, _slugs: 1 }, { sparse: true }
+          it_should_behave_like "has an index", { _type: 1, _slugs: 1 }, { unique: nil, sparse: nil }
         end
 
         context "when slug is scoped by a reference association" do

--- a/spec/shared/indexes.rb
+++ b/spec/shared/indexes.rb
@@ -1,27 +1,33 @@
 shared_examples "has an index" do |key, options|
-  it "has a #{key} index" do
-    index = if Mongoid::Slug.mongoid3?
-      subject.index_options[key]
-    else
-      subject.index_specifications.detect { |spec| spec.key == key }
-    end
-    index.should_not be_nil
+  it "has a #{[key, options].compact.join(', ')} index" do
+    index_key, index_value = select_index(subject, key)
+
+    # assert exact order of index keys
+    index_key.keys.should   eq key.keys
+    index_key.values.should eq key.values
+
     options.each_pair { |name, value|
       if Mongoid::Slug.mongoid3?
-        index[name].should == value
+        index_value[name].should == value
       else
-        index.options[name].should == value
+        index_value.options[name].should == value
       end
     } if options
   end
 end
 
-shared_examples "does not have an index" do |key, option|
+shared_examples "does not have an index" do |key|
   it "does not have the #{key} index" do
-    if Mongoid::Slug.mongoid3?
-      subject.index_options[key].should be_nil
-    else
-      subject.index_specifications.detect { |spec| spec.key == key }.should be_nil
-    end
+    index_key, index_value = select_index(subject, key)
+    index_key.should   be_nil
+    index_value.should be_nil
+  end
+end
+
+def select_index(subject, key)
+  if Mongoid::Slug.mongoid3?
+    subject.index_options.select{|k, v| k == key}.first
+  else
+    subject.index_specifications.select{|spec| spec.key == key}.first
   end
 end


### PR DESCRIPTION
- `:sparse` is now always set (no harm in setting it, in theory speeds up some edge cases where `_slugs` is unset on a large number of records)
- `:unique` is now always set EXCEPT for an edge case related to paranoid docs. Previously we were not setting `unique` when `by_model_type` was true, however, I cannot think of any reason not to set it in this case.
