### PR TITLE
Fix: queryable scope incorrectly combined.

### DIFF
--- a/spec/models/artist.rb
+++ b/spec/models/artist.rb
@@ -1,0 +1,8 @@
+class Artist
+  include Mongoid::Document
+  include Mongoid::Slug
+
+  slug :name
+  field :name
+  has_and_belongs_to_many :artworks
+end

--- a/spec/models/artwork.rb
+++ b/spec/models/artwork.rb
@@ -1,0 +1,10 @@
+class Artwork
+  include Mongoid::Document
+  include Mongoid::Slug
+
+  slug :title
+  field :title
+  field :published, type: Boolean, default: true
+  scope :published, -> { where(published: true) }
+  has_and_belongs_to_many :artists
+end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -187,4 +187,22 @@ describe Mongoid::Slug::Criteria do
       end
     end
   end
+
+  describe '.where' do
+    let!(:artist1) { Artist.create!(name: 'Leonardo') }
+    let!(:artist2) { Artist.create!(name: 'Malevich') }
+    let!(:artwork1) { Artwork.create!(title: 'Mona Lisa', artist_ids: [artist1.id], published: true) }
+    let!(:artwork2) { Artwork.create!(title: 'Black Square', artist_ids: [artist2.id], published: false) }
+    let!(:artwork3) { Artwork.create! }
+
+    it 'counts artworks' do
+      expect(Artwork.in(artist_ids: artist1.id).count).to eq 1
+      expect(Artwork.in(artist_ids: artist2.id).count).to eq 1
+    end
+
+    it 'counts published artworks' do
+      expect(Artwork.in(artist_ids: artist1.id).published.count).to eq 1
+      expect(Artwork.in(artist_ids: artist2.id).published.count).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
Another fix for Mongoid 5.0.1, continuation of #197. See https://github.com/mongodb/mongoid/pull/4179 for what changed.