### PR TITLE
refs #177 added rake task to set slug for legacy data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Your contribution here.
 
+## 5.1.2
+
+* [#177](https://github.com/digitalplaywright/mongoid-slug/issues/177): Added rake task to set slug for legacy data - [@anuja-joshi](https://github.com/anuja-joshi).
+
 ## 5.1.1
 
 * [#197](https://github.com/digitalplaywright/mongoid-slug/pull/197): Compatibility with Mongoid 5.0.1, fix [MONGOID-4177](https://jira.mongodb.org/browse/MONGOID-4177) - [@dblock](https://github.com/dblock).

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ post = Post.find '50b1386a0482939864000001' # Finds by bson ids
 ```
 [Examine slug.rb](lib/mongoid/slug.rb) for all available options.
 
+To set slugs for existing records run following rake task:
+
+```ruby
+rake mongoid_slug:set
+```
+You can pass model names as an option for which you want to set slugs:
+
+```ruby
+rake mongoid_slug:set[Model1,Model2]
+```
 Custom Slug Generation
 -------
 

--- a/lib/mongoid/slug.rb
+++ b/lib/mongoid/slug.rb
@@ -6,6 +6,7 @@ require 'mongoid/slug/paranoia'
 require 'mongoid/slug/unique_slug'
 require 'mongoid/slug/slug_id_strategy'
 require 'mongoid-compatibility'
+require 'mongoid/slug/railtie' if defined?(Rails)
 
 module Mongoid
   # Slugs your Mongoid model.

--- a/lib/mongoid/slug/railtie.rb
+++ b/lib/mongoid/slug/railtie.rb
@@ -1,0 +1,9 @@
+module Mongoid
+  module Slug
+    class Railtie < Rails::Railtie
+      rake_tasks do
+        Dir[File.join(File.dirname(__FILE__), '../../tasks/*.rake')].each { |f| load f }
+      end
+    end
+  end
+end

--- a/lib/tasks/mongoid_slug.rake
+++ b/lib/tasks/mongoid_slug.rake
@@ -1,0 +1,18 @@
+namespace :mongoid_slug do
+  desc 'Goes though all documents and sets slug if not already set'
+  task set: :environment do |_, args|
+    ::Rails.application.eager_load! if defined?(Rails)
+    klasses = Module.constants.find_all do |const|
+      const != const.upcase ? Mongoid::Slug > (Object.const_get const) : nil
+    end
+    klasses.map! { |klass| klass.to_s.constantize }
+    unless klasses.blank?
+      models  = args.extras
+      klasses = (klasses.map(&:to_s) & models.map(&:classify)).map(&:constantize) if models.any?
+      klasses.each do |klass|
+        # set slug for objects having blank slug
+        klass.each { |object| object.set_slug! unless object.slugs? }
+      end
+    end
+  end
+end

--- a/spec/tasks/mongoid_slug_rake_spec.rb
+++ b/spec/tasks/mongoid_slug_rake_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'mongoid_slug:set' do
+  before :all do
+    load File.expand_path('../../../lib/tasks/mongoid_slug.rake', __FILE__)
+    Rake::Task.define_task(:environment)
+  end
+
+  context 'when models parameter is passed' do
+    before :all do
+      UninitalizedSlugFirst = Class.new do
+        include Mongoid::Document
+        field :name, type: String
+        store_in collection: 'uninitalized_slug_first'
+      end
+      UninitalizedSlugSecond = Class.new do
+        include Mongoid::Document
+        field :name, type: String
+        store_in collection: 'uninitalized_slug_second'
+      end
+    end
+
+    it 'goes though all documents of passed models and sets slug if not already set' do
+      uninitalized_slug1 = UninitalizedSlugFirst.create(name: 'uninitalized-slug1')
+      uninitalized_slug2 = UninitalizedSlugSecond.create(name: 'uninitalized-slug2')
+
+      UninitalizedSlugFirst.class_eval do
+        include Mongoid::Slug
+        slug :name
+      end
+      UninitalizedSlugSecond.class_eval do
+        include Mongoid::Slug
+        slug :name
+      end
+
+      expect(uninitalized_slug1.slugs).to be_nil
+      expect(uninitalized_slug2.slugs).to be_nil
+
+      Rake::Task['mongoid_slug:set'].reenable
+      Rake::Task['mongoid_slug:set'].invoke('UninitalizedSlugFirst')
+
+      expect(uninitalized_slug1.reload.slugs).to eq(['uninitalized-slug1'])
+      expect(uninitalized_slug2.reload.slugs).to eq []
+    end
+  end
+
+  context 'when models parameter is not passed' do
+    before :all do
+      UninitalizedSlugThird = Class.new do
+        include Mongoid::Document
+        field :name, type: String
+        store_in collection: 'uninitalized_slug_third'
+      end
+    end
+
+    it 'goes though all documents and sets slug if not already set' do
+      uninitalized_slug3 = UninitalizedSlugThird.create(name: 'uninitalized-slug3')
+
+      UninitalizedSlugThird.class_eval do
+        include Mongoid::Slug
+        slug :name
+      end
+
+      expect(uninitalized_slug3.slugs).to be_nil
+
+      Rake::Task['mongoid_slug:set'].reenable
+      Rake::Task['mongoid_slug:set'].invoke
+
+      expect(uninitalized_slug3.reload.slugs).to eq(['uninitalized-slug3'])
+    end
+  end
+end


### PR DESCRIPTION
- Added rake task `rake mongoid_slug:set` that will set slug for existing records, if not already set.
- We can pass optional parameters to task like `rake mongoid_slug:set[Model1,Model2]` so that slug will get set for records of only these models.
- To load this task into `Rails`, I loaded task using `Rails::Railtie` so this task will be directly available to `Rails` projects. For other frameworks user have to load tasks file into their rake stack.
- Added associated test cases.