### PR TITLE
[refs #206] Fix TravisCI builds: Update bundler before installing gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.2
+
+before_install:
+  - gem update bundler


### PR DESCRIPTION
Travis bundler versions are quite out of date and can cause install errors, So updated `bundler` in`before_install` 
see: https://github.com/rubygems/rubygems/issues/1419