### PR TITLE
Allow failure for HEAD of mongoid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ addons:
       - mongodb-3.2-precise
     packages:
       - mongodb-org-server
+
+matrix:
+  allow_failures:
+    - env: MONGOID_VERSION=HEAD


### PR DESCRIPTION
I sent pull request for Global configuration ([here](https://github.com/digitalplaywright/mongoid-slug/pull/196)). All specs are passing on local machine but failing on travis so allowing failure for mongoid HEAD as discussed.