### PR TITLE
Bug: an optional has_many/belongs_to yields a unique index constraint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ class Employee
   field :name
   referenced_in :company
 
-  slug  :name, scope: :company
+  slug :name, scope: :company
 end
 ```
 
@@ -152,7 +152,7 @@ Currently, if you have an irregular association name, you **must** specify the `
 
 Embedded objects are automatically scoped by their parent.
 
-The value of `:scope` can alternatively be a field within the model itself:
+Note that the unique index on the `Employee` collection in this example is derived from the `scope` value and is `{ _slugs: 1, company_id: 1}`. Therefore `:company` must be `referenced_in` above the definition of `slug` or it will not be able to resolve the association and mistakenly create a `{ _slugs: 1, company: 1}` index. An alternative is to scope to the field itself as follows:
 
 ```ruby
 class Employee
@@ -162,7 +162,7 @@ class Employee
   field :name
   field :company_id
 
-  slug  :name, scope: :company_id
+  slug :name, scope: :company_id
 end
 ```
 

--- a/spec/models/author.rb
+++ b/spec/models/author.rb
@@ -3,7 +3,6 @@ class Author
   include Mongoid::Slug
   field :first_name
   field :last_name
-  slug :first_name, :last_name, scope: :book, history: false, max_length: 256
   if Mongoid::Compatibility::Version.mongoid6?
     belongs_to :book, required: false
   else
@@ -12,4 +11,5 @@ class Author
   has_many :characters,
            class_name: 'Person',
            foreign_key: :author_id
+  slug :first_name, :last_name, scope: :book, history: false, max_length: 256
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,18 @@ RSpec.configure do |c|
 
   c.before(:each) do
     Mongoid.purge!
+    Author.create_indexes
     Book.create_indexes
+    AuthorPolymorphic.create_indexes
+    BookPolymorphic.create_indexes
     Mongoid::IdentityMap.clear if defined?(Mongoid::IdentityMap)
+  end
+
+  c.after(:all) do
+    if Mongoid::Compatibility::Version.mongoid3? || Mongoid::Compatibility::Version.mongoid4?
+      Mongoid.default_session.drop
+    else
+      Mongoid::Clients.default.database.drop
+    end
   end
 end


### PR DESCRIPTION
The error here is caused by `Author` having a `belongs_to :book` which is not required. We create an author that doesn't belong to a book with `Author.create!(first_name: 'Leo', last_name: 'Tostoy')`, which creates a slug `leo-tolstoy`, then we create one that belongs to the book, which doesn't find the first author and re-attempts to create a `leo-tolstoy` record which causes `Mongo::Error::OperationFailure: E11000 duplicate key error index: mongoid_slug_test.authors.$_slugs_1_book_1 dup key: { : "leo-tostoy", : null } (11000)`.